### PR TITLE
Read Go version from go.mod in CI workflows

### DIFF
--- a/.github/workflows/kind-test.yaml
+++ b/.github/workflows/kind-test.yaml
@@ -5,11 +5,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
-
-      - uses: actions/checkout@v6
+          go-version-file: go.mod
 
       - uses: ko-build/setup-ko@v0.9
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,6 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - run: go test -v ./...


### PR DESCRIPTION
## Summary
- CI workflows now read the Go version via `actions/setup-go`'s `go-version-file: go.mod` instead of hardcoding `go-version: "1.25"`, so the version is defined in one place.
- Reordered `kind-test` to run `actions/checkout` before `actions/setup-go`, since `go-version-file` needs `go.mod` present on disk.

This mirrors the single-source-of-truth Go version setup applied in caddyshardrouter — bumping Go now only requires editing `go.mod`.

## Test plan
- [ ] `golangci-lint`, `tests`, and `kind-test` workflows pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)